### PR TITLE
Prevent in game joining

### DIFF
--- a/client/view.js
+++ b/client/view.js
@@ -53,13 +53,13 @@ export default class View
 
 	#initBus()
 	{
-		this.#bus.subscribe('game-created', game => this.#gameStarted(game));
-		this.#bus.subscribe('game-joined', game => this.#gameStarted(game));
+		this.#bus.subscribe('game-created', game => this.#openGameRoom(game));
+		this.#bus.subscribe('game-joined', game => this.#openGameRoom(game));
 		this.#bus.subscribe('hand-played', hand => this.#handPlayed(hand));
 		this.#bus.subscribe('hands-updated', (hands, gameStarted) => this.#handsUpdated(hands, gameStarted));
 	}
 
-	#gameStarted(game)
+	#openGameRoom(game)
 	{
 		this.$lobby.classList.add('d-none');
 		this.$gameTable.classList.remove('d-none');

--- a/client/view.js
+++ b/client/view.js
@@ -17,7 +17,7 @@ export default class View
 
 		$container.querySelector('button.js-join-game').addEventListener('click', e => {
 			e.preventDefault();
-			this.#bus.publish('join-game', $container.querySelector('input[name=game-id]').value, this.$playerName.value
+			this.#bus.publish('get-game-status', $container.querySelector('input[name=game-id]').value, this.$playerName.value
 			);
 		}, false);
 
@@ -54,9 +54,15 @@ export default class View
 	#initBus()
 	{
 		this.#bus.subscribe('game-created', game => this.#openGameRoom(game));
-		this.#bus.subscribe('game-joined', game => this.#openGameRoom(game));
+		this.#bus.subscribe('game-joined', (game) => this.#openGameRoom(game));
+		this.#bus.subscribe('send-alert', (gameStatus) => this.#sendAlert(gameStatus));
 		this.#bus.subscribe('hand-played', hand => this.#handPlayed(hand));
 		this.#bus.subscribe('hands-updated', (hands, gameStarted) => this.#handsUpdated(hands, gameStarted));
+	}
+
+	#sendAlert(gameStatus) {
+		if(gameStatus.gameStatus)
+		alert("This game has already started")
 	}
 
 	#openGameRoom(game)

--- a/server/controller.js
+++ b/server/controller.js
@@ -26,13 +26,17 @@ export default class Controller
 				var playersHands = await this.#addPlayer(game.id, data.playerId, data.playerName, data.gameOwner, Game.gameStarted);
 				this.updateAllPlayersHands(playersHands);
 				return;
-	
-			case 'join':
-				var playersHands = await this.#addPlayer(data.gameId, data.playerId, data.playerName, data.gameOwner);
-				await this.#acknowledge(data.playerId, data.messageId);
-				this.updateAllPlayersHands(playersHands);
+
+			case 'server-game-status':
+				let gameStatus = this.#getGameStatus(data.gameId);
+				await this.#acknowledge(data.playerId, data.messageId,{gameStatus: gameStatus});
 				break;
-	
+				
+			case 'join':
+					var playersHands = await this.#addPlayer(data.gameId, data.playerId, data.playerName, data.gameOwner);
+					await this.#acknowledge(data.playerId, data.messageId);
+					this.updateAllPlayersHands(playersHands);
+					break;
 			case 'deal':
 				await this.#deal(data.gameId, data.numJokers, data.dealerPlayerId);
 				await this.#acknowledge(data.playerId, data.messageId);
@@ -41,8 +45,13 @@ export default class Controller
 			case 'play-hand':
 				await this.#playHand(data.gameId, data.playerId, data.cards);
 				await this.#acknowledge(data.playerId, data.messageId);
+			}
+	}
 
-		}
+	#getGameStatus(gameId) {
+		let game = this.#games[gameId];
+		let gameStatus = game.gameStatus()
+		return gameStatus;
 	}
 
 	#generateGameId(){
@@ -72,7 +81,8 @@ export default class Controller
 	#addPlayer(gameId, playerId, playerName, gameOwner)	
 	{
 		let game = this.#games[gameId];
-		return game.addPlayer(playerId, playerName, gameOwner);
+		let newPlayer = game.addPlayer(playerId, playerName, gameOwner);
+		return newPlayer
 	}
 
 	/// Deals the decks to all players

--- a/server/game.js
+++ b/server/game.js
@@ -1,6 +1,5 @@
 const suits = [ 'D', 'H', 'C', 'S' ];
 const numerics = [ 'A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K' ];
-let gameStarted
 
 export default class Game
 {
@@ -9,6 +8,7 @@ export default class Game
 	#players = {}
 	#playedHands = [];
 	#currentPlayerIndex = null;
+	#gameStarted = false;
 
 	constructor(name, id)
 	{
@@ -19,7 +19,6 @@ export default class Game
 	/// Adds a player to the game
 	addPlayer(id, name, gameOwner)
 	{
-		gameStarted = false
 		// TODO: prevent in-progress joining
 		// TODO: limit to max-players
 		this.#players[id] = {
@@ -29,7 +28,8 @@ export default class Game
 			gameOwner
 		}
 		let playersHands = this.#getPlayersHands();
-		return Promise.resolve(playersHands);
+		if(!this.#gameStarted)
+			return Promise.resolve(playersHands);
 	}
 
 	/// Deals all cards + numJokers to all players, starting with the given dealer (or by randomly choosing a dealer)
@@ -41,6 +41,10 @@ export default class Game
 		this.#dealDeck(deck, dealerPlayerId);
 		let playersHands = this.#getPlayersHands();
 		return Promise.resolve(playersHands);
+	}
+
+	gameStatus() {
+		return this.#gameStarted
 	}
 
 	/// Builds a shuffled deck of 52 + numJokers cards
@@ -87,7 +91,7 @@ export default class Game
 	/// Deals the given deck to all players
 	#dealDeck(deck)
 	{
-		gameStarted = true
+		this.#gameStarted = true
 		let playersArray = Object.values(this.#players)
 		let p = this.#currentPlayerIndex;
 
@@ -121,7 +125,7 @@ export default class Game
 						cards: player.cards,
 						currentPlayer: this.#currentPlayerIndex == i,
 						gameOwnerButton: player.gameOwner,
-						gameStarted, gameStarted
+						gameStarted: this.#gameStarted
 					};
 					// your own hand, but not the game owner
 				else if (player.id == playersArray[p].id)


### PR DESCRIPTION
I've written this so that before a player can join the game, the game status is checked (true/false), only if the game status is false (i.e. game hasn't started) will they be added. The player gets an alert if the play has already started. 

Also reworded the gameStarted function in view.js, previously this ran when the 'create game' or the 'join game' buttons were clicked. But the game doesn't actually start until it's dealt, so it's changed to openGameRoom

This felt necessary as the join-game outcome is dependent on whether the game has started, not whether they're in the game room.